### PR TITLE
add develop command

### DIFF
--- a/src/tutorial/catalog.nw
+++ b/src/tutorial/catalog.nw
@@ -478,6 +478,14 @@ Each top-level heading begins a new tutorial step.  Lower-level headings
 remain part of the step body, which lets tutorial authors keep ordinary
 Markdown structure inside a step.
 
+Fenced examples create one important contrast: a line that begins with
+[[# ]] can either be a real step heading or just example content inside a
+code block.  That matters in [[writing-tutorials]], where one step shows a
+Markdown example containing [[# Say hello]] and later steps use longer
+outer fences to quote shorter inner [[tutorial-step]] fences.  We
+therefore remember the currently open fence delimiter and only treat
+[[# ]] as a new step heading when no fence is open.
+
 <<functions>>=
 def split_step_sections(body: str) -> tuple[tuple[str, str], ...]:
     """Return ``(title, body)`` pairs for each top-level step heading."""
@@ -485,15 +493,23 @@ def split_step_sections(body: str) -> tuple[tuple[str, str], ...]:
     sections = []
     title = None
     body_lines = []
+    open_fence = None
     for line in body.splitlines():
-        if line.startswith("# "):
-            if title is not None:
-                sections.append((title, "\n".join(body_lines).strip()))
-            title = line[2:].strip()
-            if not title:
-                raise ValueError("Tutorial step headings must not be empty.")
-            body_lines = []
-            continue
+        stripped = line.lstrip()
+        if open_fence is None:
+            if stripped.startswith("```"):
+                width = len(stripped) - len(stripped.lstrip("`"))
+                open_fence = "`" * width
+            elif line.startswith("# "):
+                if title is not None:
+                    sections.append((title, "\n".join(body_lines).strip()))
+                title = line[2:].strip()
+                if not title:
+                    raise ValueError("Tutorial step headings must not be empty.")
+                body_lines = []
+                continue
+        elif stripped.startswith(open_fence):
+            open_fence = None
 
         if title is None:
             if line.strip():
@@ -509,6 +525,43 @@ def split_step_sections(body: str) -> tuple[tuple[str, str], ...]:
 
     sections.append((title, "\n".join(body_lines).strip()))
     return tuple(sections)
+@
+
+Let's verify that step splitting ignores headings inside fenced examples,
+including examples that use a longer outer fence around a shorter inner
+one:
+
+<<test functions>>=
+def test_load_tutorial_file_ignores_step_headings_inside_code_fences(tmp_path):
+    tutorial_path = tmp_path / "demo.md"
+    tutorial_path.write_text(
+        "---\n"
+        "id: demo\n"
+        "title: Demo\n"
+        "summary: A short tutorial.\n"
+        "---\n\n"
+        "# Add a contains match\n\n"
+        "Keep the same tutorial and add a metadata fence:\n\n"
+        "````md\n"
+        "# Say hello\n\n"
+        "```tutorial-step\n"
+        "required_patterns:\n"
+        "  - echo hello\n"
+        "```\n\n"
+        "Run `echo hello`.\n"
+        "````\n\n"
+        "# Load the tutorial from disk\n\n"
+        "Run `tutorial list --tutorial-path my-tutorials`.\n"
+    )
+
+    tutorial = load_tutorial_file(tutorial_path)
+
+    assert [step.title for step in tutorial.steps] == [
+        "Add a contains match",
+        "Load the tutorial from disk",
+    ]
+    assert "# Say hello" in tutorial.steps[0].instructions
+    assert "Run `echo hello`." in tutorial.steps[0].instructions
 @
 
 

--- a/src/tutorial/catalog.nw
+++ b/src/tutorial/catalog.nw
@@ -1097,3 +1097,185 @@ def get_tutorial(
 
     return TutorialCatalog(tutorial_paths).get_tutorial(tutorial_id)
 @
+
+
+\section{Serialising one tutorial step back to Markdown}
+
+Authoring tools need to round-trip a [[TutorialStep]] through Markdown so an
+author can inspect the rendered source, drop it into a tutorial file, or
+re-open the same step for further editing.  Serialisation mirrors
+[[build_tutorial_step]]: only fields the parser would set are emitted, and
+recorded-text matches use the same string-or-mapping shape the parser
+already accepts.
+
+<<functions>>=
+def serialize_text_match(match: TextMatch) -> object:
+    """Return ``match`` as the YAML shape that ``text_match`` accepts."""
+
+    if match.mode == "contains":
+        return match.pattern
+    return {"mode": match.mode, "pattern": match.pattern}
+@
+
+<<functions>>=
+def step_metadata_for_serialization(step: TutorialStep) -> dict:
+    """Return the YAML metadata mapping for ``step`` (only non-default fields)."""
+
+    metadata: dict = {}
+    if step.kind is not None:
+        metadata["kind"] = step.kind
+    if step.options:
+        metadata["options"] = list(step.options)
+    if step.answers:
+        if step.kind == "input":
+            metadata["answers"] = [
+                serialize_text_match(answer) for answer in step.answers
+            ]
+        else:
+            metadata["answers"] = list(step.answers)
+    if step.required_patterns:
+        metadata["required_patterns"] = [
+            serialize_text_match(pattern) for pattern in step.required_patterns
+        ]
+    if step.check_command is not None:
+        metadata["check_command"] = step.check_command
+    if step.hint is not None:
+        metadata["hint"] = step.hint
+    if step.edit_file is not None:
+        metadata["edit_file"] = step.edit_file
+    return metadata
+@
+
+<<functions>>=
+def serialize_tutorial_step(step: TutorialStep) -> str:
+    """Render ``step`` as the Markdown a tutorial file would contain."""
+
+    parts = [f"# {step.title}", ""]
+    metadata = step_metadata_for_serialization(step)
+    if metadata:
+        body = yaml.safe_dump(
+            metadata,
+            sort_keys=False,
+            default_flow_style=False,
+        ).rstrip()
+        parts.extend([STEP_METADATA_FENCE, body, "```", ""])
+    parts.append(step.instructions.rstrip())
+    return "\n".join(parts) + "\n"
+@
+
+<<test functions>>=
+def test_serialize_tutorial_step_round_trips_minimal_step():
+    step = TutorialStep(
+        title="Step one",
+        instructions="Run `pwd`.",
+    )
+
+    rendered = serialize_tutorial_step(step)
+
+    assert "```tutorial-step" not in rendered
+    sections = split_step_sections(rendered)
+    assert len(sections) == 1
+    title, body = sections[0]
+    assert title == "Step one"
+    assert build_tutorial_step(title, body) == step
+
+
+def test_serialize_tutorial_step_round_trips_step_with_metadata():
+    step = TutorialStep(
+        title="Edit notes",
+        instructions="Open `notes.txt` and add your name.",
+        required_patterns=(
+            TextMatch("name"),
+            TextMatch("^A.*", mode="regex"),
+        ),
+        check_command="test -s notes.txt",
+        hint="Try `vim notes.txt`.",
+        edit_file="notes.txt",
+    )
+
+    rendered = serialize_tutorial_step(step)
+
+    sections = split_step_sections(rendered)
+    title, body = sections[0]
+    assert build_tutorial_step(title, body) == step
+
+
+def test_serialize_tutorial_step_round_trips_input_question():
+    step = TutorialStep(
+        title="Type the command",
+        instructions="Type `pwd`.",
+        kind="input",
+        answers=(TextMatch("pwd"),),
+    )
+
+    rendered = serialize_tutorial_step(step)
+
+    sections = split_step_sections(rendered)
+    title, body = sections[0]
+    assert build_tutorial_step(title, body) == step
+
+
+def test_serialize_tutorial_step_round_trips_select_question():
+    step = TutorialStep(
+        title="Pick the listing command",
+        instructions="Choose the command that lists files.",
+        kind="single_select",
+        options=("pwd", "ls", "cd"),
+        answers=("ls",),
+    )
+
+    rendered = serialize_tutorial_step(step)
+
+    sections = split_step_sections(rendered)
+    title, body = sections[0]
+    assert build_tutorial_step(title, body) == step
+@
+
+
+\section{Parsing one tutorial step from Markdown}
+
+The [[develop]] command reads back what an author edited and needs the same
+guarantees as [[load_tutorial_file]]: exactly one heading, valid metadata,
+recognisable interaction shape.  The single-step parser is a thin wrapper
+over [[split_step_sections]] and [[build_tutorial_step]] so the rules stay
+in one place.
+
+<<functions>>=
+def parse_tutorial_step_markdown(text: str) -> TutorialStep:
+    """Parse a single-step Markdown blob (heading + body) into a [[TutorialStep]]."""
+
+    sections = split_step_sections(text)
+    if len(sections) != 1:
+        raise ValueError(
+            "Expected exactly one '# ' step heading; "
+            f"found {len(sections)}."
+        )
+    title, body = sections[0]
+    return build_tutorial_step(title, body)
+@
+
+<<test functions>>=
+def test_parse_tutorial_step_markdown_round_trips_minimal_step():
+    rendered = (
+        "# Step one\n"
+        "\n"
+        "Run `pwd`.\n"
+    )
+
+    step = parse_tutorial_step_markdown(rendered)
+
+    assert step.title == "Step one"
+    assert step.instructions == "Run `pwd`."
+
+
+def test_parse_tutorial_step_markdown_rejects_zero_headings():
+    with pytest.raises(ValueError):
+        parse_tutorial_step_markdown("Just some text without a heading.\n")
+
+
+def test_parse_tutorial_step_markdown_rejects_multiple_headings():
+    with pytest.raises(ValueError):
+        parse_tutorial_step_markdown(
+            "# Step one\n\nFirst.\n\n# Step two\n\nSecond.\n"
+        )
+@

--- a/src/tutorial/cli.nw
+++ b/src/tutorial/cli.nw
@@ -19,6 +19,8 @@ layer and only varies the argument plumbing.
 
 <<imports>>
 
+<<constants>>
+
 <<functions>>
 
 app = create_standalone_app()
@@ -40,6 +42,7 @@ from typer.testing import CliRunner
 
 from tutorial.cli import *
 from tutorial.model import StepTranscript
+from tutorial.model import TextMatch
 from tutorial.model import Tutorial
 from tutorial.model import TutorialStep
 from tutorial.shell import EditorResult
@@ -243,8 +246,11 @@ import argparse
 import csv
 import json
 from pathlib import Path
+import re
+import tempfile
 from typing import Annotated
 from typing import Callable
+from typing import Optional
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -252,7 +258,9 @@ import urllib.request
 import platformdirs
 from tutorial.catalog import TutorialCatalog
 from tutorial.catalog import builtin_tutorial_paths
+from tutorial.catalog import parse_tutorial_step_markdown
 from tutorial.catalog import parse_tutorial_text
+from tutorial.catalog import serialize_tutorial_step
 from tutorial.catalog import universal_tutorial_path
 from rich.console import Console
 from rich.markdown import Markdown
@@ -260,8 +268,13 @@ from rich.table import Table
 import typer
 
 from tutorial.model import step_kind
+from tutorial.model import TutorialStep
+from tutorial.run import perform_step
+from tutorial.run import recorded_text
 from tutorial.run import RunResult
 from tutorial.run import TutorialRunner
+from tutorial.run import validate_step
+from tutorial.shell import EditorResult
 from tutorial.shell import run_editor
 from tutorial.shell import run_interactive_shell
 from tutorial.shell import ShellResult
@@ -2524,6 +2537,8 @@ def create_standalone_app(
 
         typer.echo(f"Installed {tutorial_id} at {target_path}")
 
+    <<register develop command>>
+
     return application
 @
 
@@ -3341,4 +3356,760 @@ def test_argparse_run_command_handles_question_steps(
     assert "Choose one option" in captured.out
     assert "Choose all that apply" in captured.out
     assert "Completed shell-basics" in captured.out
+@
+
+
+\section{Develop: an authoring loop for one step}
+
+The [[develop]] command is the only command that exists purely to support
+authoring tutorials.  Its job is to let the author iterate on a single step
+in a fresh workspace, see whether the runner agrees with their intent, and
+fix the step source whenever the verdict is wrong.
+
+It deliberately bypasses the persistence layer.  Saved runs and resume
+state would only get in the way: the author is changing the step itself,
+so each iteration is a clean slate.  The loop reuses
+[[perform_step]], [[recorded_text]], and [[validate_step]] so the verdict
+develop reports is the verdict [[run]] would give end users.
+
+\subsection{Resolving an existing step}
+
+The author identifies a step by either its 1-indexed number or a
+case-insensitive regex matched against [[step.title]].  We try the number
+first and fall back to the regex so the more specific form wins when both
+forms could apply.
+
+<<functions>>=
+def parse_step_locator(
+    locator: str,
+    steps: tuple[TutorialStep, ...],
+) -> TutorialStep:
+    """Resolve ``locator`` to one [[TutorialStep]] by number or title regex."""
+
+    locator = locator.strip()
+    if not locator:
+        raise ValueError("Step locator must not be empty.")
+
+    try:
+        index = int(locator) - 1
+    except ValueError:
+        index = None
+
+    if index is not None:
+        if not 0 <= index < len(steps):
+            raise ValueError(
+                f"Step number {locator} is out of range "
+                f"(tutorial has {len(steps)} step(s))."
+            )
+        return steps[index]
+
+    try:
+        pattern = re.compile(locator, re.IGNORECASE)
+    except re.error as error:
+        raise ValueError(
+            f"Step locator {locator!r} is neither a number nor a valid regex: {error}."
+        )
+
+    matches = [step for step in steps if pattern.search(step.title)]
+    if not matches:
+        raise ValueError(f"No step title matches regex {locator!r}.")
+    if len(matches) > 1:
+        titles = ", ".join(repr(step.title) for step in matches)
+        raise ValueError(
+            f"Step regex {locator!r} matches more than one step: {titles}."
+        )
+    return matches[0]
+@
+
+<<test functions>>=
+def test_parse_step_locator_resolves_by_number():
+    steps = (
+        TutorialStep(title="One", instructions="First."),
+        TutorialStep(title="Two", instructions="Second."),
+    )
+
+    assert parse_step_locator("2", steps) is steps[1]
+
+
+def test_parse_step_locator_resolves_by_regex():
+    steps = (
+        TutorialStep(title="Edit notes", instructions="First."),
+        TutorialStep(title="Run shell", instructions="Second."),
+    )
+
+    assert parse_step_locator("^Run", steps) is steps[1]
+
+
+def test_parse_step_locator_rejects_ambiguous_regex():
+    steps = (
+        TutorialStep(title="Edit notes", instructions="First."),
+        TutorialStep(title="Edit list", instructions="Second."),
+    )
+
+    with pytest.raises(ValueError):
+        parse_step_locator("^Edit", steps)
+
+
+def test_parse_step_locator_rejects_out_of_range_number():
+    steps = (TutorialStep(title="One", instructions="First."),)
+
+    with pytest.raises(ValueError):
+        parse_step_locator("5", steps)
+@
+
+
+\subsection{Pre-filling the editor for a new step or a re-edit}
+
+New-step mode opens the editor on a starter template that already parses,
+so the author can save without first reaching for the [[tutorial-step]]
+syntax.  The re-edit mode appends the most recent run to the same file
+behind a sentinel line: the author edits the step source above the
+sentinel, and the loop strips everything from the sentinel onwards before
+re-parsing.
+
+We use a plain-text sentinel rather than an HTML comment because tutorial
+step bodies are Markdown, so an HTML comment that happens to contain
+[[-->]] would close early and surprise the author.
+
+<<constants>>=
+DEVELOP_NEW_STEP_TEMPLATE = (
+    "# New step\n"
+    "\n"
+    "```tutorial-step\n"
+    "required_patterns:\n"
+    "  - example-command\n"
+    "hint: Try running example-command.\n"
+    "```\n"
+    "\n"
+    "Replace this paragraph with the step instructions.\n"
+)
+DEVELOP_RUN_MARKER = (
+    "<!-- ====== LAST RUN — delete this line and everything below "
+    "before saving ====== -->"
+)
+@
+
+<<functions>>=
+def compose_develop_edit_text(
+    step: TutorialStep,
+    *,
+    recorded: str,
+    verdict: bool,
+) -> str:
+    """Return editor pre-fill text: serialised step + marker + last run."""
+
+    verdict_label = "PASS" if verdict else "FAIL"
+    return (
+        f"{serialize_tutorial_step(step)}"
+        "\n"
+        f"{DEVELOP_RUN_MARKER}\n"
+        f"Verdict reported by the runner: {verdict_label}\n"
+        "Author said this verdict was wrong.\n"
+        "\n"
+        f"{recorded.rstrip()}\n"
+    )
+@
+
+<<functions>>=
+def strip_develop_run_marker(text: str) -> str:
+    """Return ``text`` with the develop run-marker section removed."""
+
+    head, sep, _ = text.partition(DEVELOP_RUN_MARKER)
+    if not sep:
+        return text
+    return head.rstrip() + "\n"
+@
+
+<<test functions>>=
+def test_compose_develop_edit_text_round_trips_step():
+    step = TutorialStep(
+        title="One",
+        instructions="Run pwd.",
+        required_patterns=(TextMatch("pwd"),),
+    )
+
+    rendered = compose_develop_edit_text(step, recorded="$ pwd\n/home\n", verdict=False)
+
+    assert DEVELOP_RUN_MARKER in rendered
+    stripped = strip_develop_run_marker(rendered)
+    assert DEVELOP_RUN_MARKER not in stripped
+    assert parse_tutorial_step_markdown(stripped) == step
+
+
+def test_strip_develop_run_marker_is_noop_when_absent():
+    text = "# Title\n\nbody.\n"
+
+    assert strip_develop_run_marker(text) == text
+@
+
+
+\subsection{Editing the step in [[\$EDITOR]]}
+
+Both new-step mode and the re-edit branch route through the same helper:
+write the pre-fill text to the editor, parse it back, and let the author
+correct parse errors interactively.  Errors print to the console and the
+helper re-opens the editor with the same buffer until the author either
+saves something parseable or ends the loop.
+
+<<functions>>=
+def edit_step_in_editor(
+    *,
+    console: Console,
+    workspace: str | Path,
+    relative_path: str,
+    initial_text: str,
+    editor_runner: Callable[..., EditorResult],
+    confirm: Callable[[str], bool],
+    sanitiser: Callable[[str], str] = lambda text: text,
+) -> TutorialStep | None:
+    """Open the editor and parse the saved file, retrying on parse errors."""
+
+    text_to_edit = initial_text
+    while True:
+        result = editor_runner(
+            workspace=workspace,
+            relative_path=relative_path,
+            initial_text=text_to_edit,
+        )
+        try:
+            return parse_tutorial_step_markdown(sanitiser(result.text))
+        except ValueError as error:
+            console.print(f"Step did not parse: {error}", style="red")
+            if not confirm("Re-open the editor to fix it?"):
+                return None
+            text_to_edit = result.text
+@
+
+
+\subsection{Registering the [[develop]] command}
+
+The command lives only on the standalone wrapper, mirroring [[install]]:
+embedded hosts do not register it, so they neither expose nor accept it.
+Inside the loop we reuse [[runner]]-equivalent wiring (shell, editor and
+question runners from the closure) directly, since the develop loop is
+allowed to ignore the persistence layer the runner factory threads in.
+
+<<register develop command>>=
+@application.command("develop")
+def develop_command(
+    tutorial_id: Annotated[
+        Optional[str],
+        typer.Argument(
+            help=(
+                "Tutorial ID for an existing step. Omit (with --step) to "
+                "draft a brand new step."
+            ),
+        ),
+    ] = None,
+    step: Annotated[
+        Optional[str],
+        typer.Argument(
+            help="Step number (1-indexed) or a regex matching the step title.",
+        ),
+    ] = None,
+    tutorial_path: Annotated[
+        list[Path] | None,
+        typer.Option(
+            "--tutorial-path",
+            help=(
+                "Path to a tutorial Markdown file or directory. "
+                "Repeat to add more paths."
+            ),
+        ),
+    ] = None,
+    allow_shell_checks_flag: Annotated[
+        bool,
+        typer.Option(
+            "--allow-shell-checks/--deny-shell-checks",
+            help=(
+                "Allow author-supplied shell check_command validation "
+                "(default on for develop)."
+            ),
+        ),
+    ] = True,
+) -> None:
+    """Develop and test a single tutorial step."""
+
+    console = Console()
+
+    if (tutorial_id is None) != (step is None):
+        raise typer.BadParameter(
+            "Provide both TUTORIAL_ID and STEP for an existing step, or "
+            "neither to draft a new step.",
+        )
+
+    with tempfile.TemporaryDirectory(prefix="tutorial-develop-") as workspace:
+        workspace_path = Path(workspace)
+
+        try:
+            current_step = resolve_initial_develop_step(
+                console=console,
+                tutorial_id=tutorial_id,
+                step_locator=step,
+                tutorial_path_arg=tutorial_path or [],
+                editor_runner=editor_runner,
+                workspace=workspace_path,
+            )
+        except ValueError as error:
+            typer.echo(str(error), err=True)
+            raise typer.Exit(code=1)
+        except KeyError as error:
+            raise typer.BadParameter(str(error), param_hint="tutorial_id")
+
+        if current_step is None:
+            typer.echo("Aborted before completing the new step.", err=True)
+            raise typer.Exit(code=1)
+
+        def prompt_for_input(prompt: str) -> str:
+            return typer.prompt(prompt)
+
+        command_question_runner = make_question_step_runner(
+            console=console,
+            prompt_for_input=prompt_for_input,
+            question_runner=question_runner,
+        )
+
+        final_step = develop_iterate(
+            console=console,
+            initial_step=current_step,
+            tutorial_id=tutorial_id or "develop",
+            workspace=workspace_path,
+            shell_runner=shell_runner,
+            editor_runner=editor_runner,
+            question_runner=command_question_runner,
+            allow_shell_checks=allow_shell_checks_flag,
+        )
+
+        final_source = serialize_tutorial_step(final_step)
+        console.print()
+        console.print("Final step source:", style="bold")
+        console.print()
+        typer.echo(final_source)
+@
+
+
+\subsection{Resolving the initial step from CLI arguments}
+
+The setup phase is small but distinct from the iterate-and-test loop, so
+it lives in its own helper.  New-step mode delegates to
+[[edit_step_in_editor]]; existing-step mode looks the tutorial up via the
+catalog using the same path resolution as [[list]]/[[run]]/[[review]].
+
+<<functions>>=
+def resolve_initial_develop_step(
+    *,
+    console: Console,
+    tutorial_id: str | None,
+    step_locator: str | None,
+    tutorial_path_arg: list[Path],
+    editor_runner: Callable[..., EditorResult],
+    workspace: Path,
+) -> TutorialStep | None:
+    """Return the step the develop loop should start with."""
+
+    if tutorial_id is None:
+        return edit_step_in_editor(
+            console=console,
+            workspace=workspace,
+            relative_path="step.md",
+            initial_text=DEVELOP_NEW_STEP_TEMPLATE,
+            editor_runner=editor_runner,
+            confirm=lambda prompt: typer.confirm(prompt, default=True),
+        )
+
+    catalog_paths = list(standalone_tutorial_paths())
+    catalog_paths.extend(tutorial_path_arg)
+    catalog = TutorialCatalog(tuple(catalog_paths))
+    tutorial = catalog.get_tutorial(tutorial_id)
+    return parse_step_locator(step_locator or "", tutorial.steps)
+@
+
+
+\subsection{The iterate-and-test loop}
+
+The loop owns the per-iteration concerns: render the prompt, run the
+backend, validate, ask the author whether the verdict was right, hand off
+to the editor when it was wrong, and decide whether to go round again.
+Splitting it out of the command callback keeps the registration body
+easy to scan and gives tests a smaller surface to target.
+
+<<functions>>=
+def develop_iterate(
+    *,
+    console: Console,
+    initial_step: TutorialStep,
+    tutorial_id: str,
+    workspace: Path,
+    shell_runner: Callable[..., ShellResult],
+    editor_runner: Callable[..., EditorResult],
+    question_runner: Callable[..., ShellResult],
+    allow_shell_checks: bool,
+) -> TutorialStep:
+    """Run the develop iterate-and-test loop and return the final step."""
+
+    step = initial_step
+    while True:
+        if step.edit_file is not None:
+            target = workspace / step.edit_file
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if not target.exists():
+                target.write_text("")
+
+        render_step_prompt(
+            console,
+            "Develop",
+            1,
+            1,
+            step.title,
+            step.instructions,
+            str(workspace),
+            kind=step_kind(step),
+            options=step.options,
+            edit_file=step.edit_file,
+        )
+
+        try:
+            result = perform_step(
+                step,
+                tutorial_id=tutorial_id,
+                workspace=workspace,
+                shell_runner=shell_runner,
+                editor_runner=editor_runner,
+                question_runner=question_runner,
+            )
+        except RuntimeError as error:
+            typer.echo(str(error), err=True)
+            return step
+
+        recorded = recorded_text(result)
+        try:
+            verdict = validate_step(
+                step,
+                recorded,
+                workspace,
+                allow_shell_checks=allow_shell_checks,
+            )
+        except RuntimeError as error:
+            typer.echo(str(error), err=True)
+            return step
+
+        verdict_label = "PASS" if verdict else "FAIL"
+        verdict_style = "green" if verdict else "red"
+        console.print()
+        console.print(f"Verdict: {verdict_label}", style=f"bold {verdict_style}")
+
+        correct = typer.confirm("Is that verdict correct?", default=True)
+        if not correct:
+            edited = edit_step_in_editor(
+                console=console,
+                workspace=workspace,
+                relative_path="step.md",
+                initial_text=compose_develop_edit_text(
+                    step, recorded=recorded, verdict=verdict,
+                ),
+                editor_runner=editor_runner,
+                confirm=lambda prompt: typer.confirm(prompt, default=True),
+                sanitiser=strip_develop_run_marker,
+            )
+            if edited is not None:
+                step = edited
+
+        if not typer.confirm("Run the step again?", default=True):
+            return step
+@
+
+
+\subsection{End-to-end develop tests}
+
+The CliRunner-driven tests stub out only the parts develop should not be
+running for real: the shell runner, the editor runner, and the user-
+installed tutorial directory.  Everything else (catalog parsing,
+[[validate_step]], [[serialize_tutorial_step]], typer prompts) runs
+exactly the way it would for an author at the terminal.
+
+<<test functions>>=
+def _develop_no_user_tutorials(monkeypatch, tmp_path):
+    """Point user_tutorial_dir at an empty directory so it stays silent."""
+
+    empty_dir = tmp_path / "user-empty"
+    empty_dir.mkdir()
+    monkeypatch.setattr("tutorial.cli.user_tutorial_dir", lambda: empty_dir)
+
+
+def _write_develop_demo(root: Path) -> Path:
+    """Write a tutorial with a unique ID so it does not collide with built-ins."""
+
+    tutorial_path = Path(root) / "develop-demo.md"
+    tutorial_path.write_text(
+        "---\n"
+        "id: develop-demo\n"
+        "title: Develop Demo\n"
+        "summary: A short tutorial for develop tests.\n"
+        "---\n\n"
+        "# Inspect the workspace\n\n"
+        "```tutorial-step\n"
+        "required_patterns:\n"
+        "  - pwd\n"
+        "  - ls\n"
+        "hint: Run pwd and ls.\n"
+        "```\n\n"
+        "Run `pwd` and `ls`.\n\n"
+        "# Edit notes\n\n"
+        "```tutorial-step\n"
+        "edit_file: notes.txt\n"
+        "required_patterns:\n"
+        "  - tutorial\n"
+        "```\n\n"
+        "Add the word `tutorial` to `notes.txt`.\n"
+    )
+    return tutorial_path
+
+
+def test_develop_command_existing_step_passes_then_prints_source(
+    monkeypatch, tmp_path,
+):
+    _develop_no_user_tutorials(monkeypatch, tmp_path)
+    tutorial_path = _write_develop_demo(tmp_path)
+
+    def fake_shell_runner(*, workspace, prompt_name=None):
+        return ShellResult(
+            started_at="2026-01-01T00:00:00+00:00",
+            ended_at="2026-01-01T00:00:01+00:00",
+            exit_status=0,
+            transcript="$ pwd\n/tmp\n$ ls\nnotes.txt\n",
+        )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        create_standalone_app(
+            state_root=tmp_path / "state",
+            shell_runner=fake_shell_runner,
+        ),
+        [
+            "develop",
+            "develop-demo",
+            "1",
+            "--tutorial-path",
+            str(tutorial_path),
+        ],
+        input="y\nn\n",
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert "Verdict: PASS" in result.stdout
+    assert "Final step source:" in result.stdout
+    assert "# Inspect the workspace" in result.stdout
+
+
+def test_develop_command_resolves_step_by_regex(monkeypatch, tmp_path):
+    _develop_no_user_tutorials(monkeypatch, tmp_path)
+    tutorial_path = _write_develop_demo(tmp_path)
+
+    def fake_shell_runner(*, workspace, prompt_name=None):
+        return ShellResult(
+            started_at="2026-01-01T00:00:00+00:00",
+            ended_at="2026-01-01T00:00:01+00:00",
+            exit_status=0,
+            transcript="$ pwd\n/tmp\n$ ls\n",
+        )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        create_standalone_app(
+            state_root=tmp_path / "state",
+            shell_runner=fake_shell_runner,
+        ),
+        [
+            "develop",
+            "develop-demo",
+            "^Inspect",
+            "--tutorial-path",
+            str(tutorial_path),
+        ],
+        input="y\nn\n",
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert "# Inspect the workspace" in result.stdout
+
+
+def test_develop_command_existing_step_reports_failure(monkeypatch, tmp_path):
+    _develop_no_user_tutorials(monkeypatch, tmp_path)
+    tutorial_path = _write_develop_demo(tmp_path)
+
+    def fake_shell_runner(*, workspace, prompt_name=None):
+        return ShellResult(
+            started_at="2026-01-01T00:00:00+00:00",
+            ended_at="2026-01-01T00:00:01+00:00",
+            exit_status=0,
+            transcript="$ echo hi\nhi\n",
+        )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        create_standalone_app(
+            state_root=tmp_path / "state",
+            shell_runner=fake_shell_runner,
+        ),
+        [
+            "develop",
+            "develop-demo",
+            "1",
+            "--tutorial-path",
+            str(tutorial_path),
+        ],
+        input="y\nn\n",
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert "Verdict: FAIL" in result.stdout
+
+
+def test_develop_command_new_step_uses_editor_template(monkeypatch, tmp_path):
+    _develop_no_user_tutorials(monkeypatch, tmp_path)
+
+    edited_step_text = (
+        "# Drafted step\n"
+        "\n"
+        "```tutorial-step\n"
+        "required_patterns:\n"
+        "  - hello\n"
+        "```\n"
+        "\n"
+        "Type hello.\n"
+    )
+
+    def fake_editor_runner(*, workspace, relative_path, initial_text=None):
+        Path(workspace, relative_path).write_text(edited_step_text)
+        return EditorResult(
+            started_at="2026-01-01T00:00:00+00:00",
+            ended_at="2026-01-01T00:00:01+00:00",
+            exit_status=0,
+            file_path=str(Path(workspace) / relative_path),
+            text=edited_step_text,
+        )
+
+    def fake_shell_runner(*, workspace, prompt_name=None):
+        return ShellResult(
+            started_at="2026-01-01T00:00:00+00:00",
+            ended_at="2026-01-01T00:00:01+00:00",
+            exit_status=0,
+            transcript="$ echo hello\nhello\n",
+        )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        create_standalone_app(
+            state_root=tmp_path / "state",
+            shell_runner=fake_shell_runner,
+            editor_runner=fake_editor_runner,
+        ),
+        ["develop"],
+        input="y\nn\n",
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert "Verdict: PASS" in result.stdout
+    assert "# Drafted step" in result.stdout
+    assert "Type hello." in result.stdout
+
+
+def test_develop_command_edits_step_on_wrong_verdict(monkeypatch, tmp_path):
+    _develop_no_user_tutorials(monkeypatch, tmp_path)
+    tutorial_path = _write_develop_demo(tmp_path)
+
+    revised_text = (
+        "# Inspect the workspace (revised)\n"
+        "\n"
+        "```tutorial-step\n"
+        "required_patterns:\n"
+        "  - pwd\n"
+        "  - ls\n"
+        "  - cat\n"
+        "```\n"
+        "\n"
+        "Run pwd, ls, and cat.\n"
+    )
+
+    def fake_editor_runner(*, workspace, relative_path, initial_text=None):
+        Path(workspace, relative_path).write_text(revised_text)
+        return EditorResult(
+            started_at="2026-01-01T00:00:00+00:00",
+            ended_at="2026-01-01T00:00:01+00:00",
+            exit_status=0,
+            file_path=str(Path(workspace) / relative_path),
+            text=revised_text,
+        )
+
+    def fake_shell_runner(*, workspace, prompt_name=None):
+        return ShellResult(
+            started_at="2026-01-01T00:00:00+00:00",
+            ended_at="2026-01-01T00:00:01+00:00",
+            exit_status=0,
+            transcript="$ pwd\n/tmp\n$ ls\nnotes.txt\n",
+        )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        create_standalone_app(
+            state_root=tmp_path / "state",
+            shell_runner=fake_shell_runner,
+            editor_runner=fake_editor_runner,
+        ),
+        [
+            "develop",
+            "develop-demo",
+            "1",
+            "--tutorial-path",
+            str(tutorial_path),
+        ],
+        input="n\nn\n",
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert "# Inspect the workspace (revised)" in result.stdout
+    assert "Run pwd, ls, and cat." in result.stdout
+
+
+def test_develop_command_rejects_partial_arguments(tmp_path):
+    runner = CliRunner()
+    result = runner.invoke(
+        create_standalone_app(state_root=tmp_path / "state"),
+        ["develop", "develop-demo"],
+    )
+
+    assert result.exit_code != 0
+
+
+def test_develop_command_reports_unknown_tutorial(monkeypatch, tmp_path):
+    _develop_no_user_tutorials(monkeypatch, tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        create_standalone_app(state_root=tmp_path / "state"),
+        ["develop", "no-such-tutorial-id-xyz", "1"],
+    )
+
+    assert result.exit_code != 0
+
+
+def test_develop_command_hidden_in_embedded_typer_app(tmp_path):
+    parent = typer.Typer()
+    add_typer_subcommand(parent, state_root=tmp_path / "state")
+
+    runner = CliRunner()
+    result = runner.invoke(parent, ["tutorial"])
+
+    assert result.exit_code == 0
+    assert "develop" not in result.stdout
+
+
+def test_develop_command_visible_in_standalone_help(tmp_path):
+    runner = CliRunner()
+    result = runner.invoke(
+        create_standalone_app(state_root=tmp_path / "state"),
+        [],
+    )
+
+    assert result.exit_code == 0
+    assert "develop" in result.stdout
 @

--- a/src/tutorial/run.nw
+++ b/src/tutorial/run.nw
@@ -1273,6 +1273,11 @@ The runner stores both shell sessions and editor sessions as step
 transcripts so the state layer can persist them without knowing anything
 about validation policy.
 
+Editor-backed review is easier to understand when it keeps the tutorial's
+authored relative path, not just the basename of the file on disk.  That
+way a step editing [[my-tutorials/greeting.md]] still reviews as that same
+path instead of the ambiguous [[greeting.md]].
+
 <<functions>>=
 def build_step_transcript(
     *,
@@ -1294,7 +1299,7 @@ def build_step_transcript(
             exit_status=step_result.exit_status,
             transcript=step_result.text,
             passed=passed,
-            edited_file=Path(step_result.file_path).name,
+            edited_file=step.edit_file,
         )
 
     return StepTranscript(
@@ -1355,6 +1360,30 @@ def test_build_step_transcript_marks_editor_source_file():
 
     assert transcript.transcript == "tutorial\n"
     assert transcript.edited_file == "notes.txt"
+
+
+def test_build_step_transcript_keeps_nested_editor_path():
+    step = TutorialStep(
+        title="Edit tutorial",
+        instructions="Open my-tutorials/greeting.md.",
+        edit_file="my-tutorials/greeting.md",
+    )
+
+    transcript = build_step_transcript(
+        tutorial_id="writing-tutorials",
+        step_index=1,
+        step=step,
+        step_result=EditorResult(
+            started_at="2026-01-01T00:00:00+00:00",
+            ended_at="2026-01-01T00:00:01+00:00",
+            exit_status=0,
+            file_path="/tmp/demo/my-tutorials/greeting.md",
+            text="---\nid: greeting\n",
+        ),
+        passed=True,
+    )
+
+    assert transcript.edited_file == "my-tutorials/greeting.md"
 @
 
 

--- a/src/tutorial/run.nw
+++ b/src/tutorial/run.nw
@@ -1557,9 +1557,11 @@ def test_validate_step_treats_multi_select_answers_as_sets(tmp_path):
 Transcript checks still default to literal matching, but interactive shell
 transcripts contain noise that students do not control: carriage returns,
 ANSI control sequences, and small whitespace differences from completion or
-line editing.  We therefore normalise those details before checking plain
-string patterns.  Tutorials that truly need more control can opt into an
-explicit regular expression.
+line editing.  Some shells also record readline redraws literally, so one
+accepted command may appear as text, a backspace, and the replacement
+characters that followed it.  We therefore normalise those details before
+checking plain string patterns.  Tutorials that truly need more control can
+opt into an explicit regular expression.
 
 <<constants>>=
 ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
@@ -1567,10 +1569,30 @@ WHITESPACE_RE = re.compile(r"\s+")
 @
 
 <<functions>>=
+def apply_line_editing(text: str) -> str:
+    """Return ``text`` after applying simple backspace-style edits."""
+
+    characters = []
+    for character in text:
+        if character in {"\b", "\x7f"}:
+            if characters:
+                characters.pop()
+            continue
+        characters.append(character)
+    return "".join(characters)
+@
+
+Readline redraw sequences matter here because a recorded backspace is not
+student-visible output; it only means the terminal overwrote the previous
+character.  Applying those edits after stripping ANSI sequences recovers the
+command the student actually left on screen.
+
+<<functions>>=
 def normalise_recorded_text(text: str) -> str:
     """Return ``text`` without terminal control noise."""
 
     text = ANSI_ESCAPE_RE.sub("", text)
+    text = apply_line_editing(text)
     text = text.replace("\r", "\n")
     return text
 @
@@ -1635,6 +1657,19 @@ def test_transcript_matches_patterns_ignores_ansi_control_sequences():
     assert transcript_matches_patterns(
         "\x1b[1mshell-basics $ \x1b[0mpwd\n",
         (TextMatch("shell-basics $"),),
+    ) is True
+
+
+def test_transcript_matches_patterns_ignores_line_redraw_backspaces():
+    assert transcript_matches_patterns(
+        "\x1b[?2004hwriting-tutorials $ mkdir my-to\b\x1b[Kutorials\r\n"
+        "\x1b[?2004l\r\x1b[?2004hwriting-tutorials $ ls\r\n"
+        "\x1b[?2004l\rmy-tutorials\r\n",
+        (
+            TextMatch("mkdir my-tutorials"),
+            TextMatch("ls"),
+            TextMatch("my-tutorials"),
+        ),
     ) is True
 
 

--- a/src/tutorial/run.nw
+++ b/src/tutorial/run.nw
@@ -1558,15 +1558,18 @@ Transcript checks still default to literal matching, but interactive shell
 transcripts contain noise that students do not control: carriage returns,
 ANSI control sequences, and small whitespace differences from completion or
 line editing.  Some shells also record readline redraws literally, so one
-accepted command may appear as text, a backspace, and the replacement
-characters that followed it.  Tab completion can also leave behind bell
-characters or similar control bytes that the student never intended as part
-of the command.  We therefore normalise those details before checking plain
-string patterns.  Tutorials that truly need more control can opt into an
-explicit regular expression.
+accepted command may appear as raw cursor-key input, cursor motion, insert and
+delete operations, and the replacement characters that followed them.  That
+includes simple arrows, modified arrows such as Ctrl-Left and Ctrl-Right, and
+word-oriented motion such as Alt-b and Alt-f when readline redraws the line.
+Tab completion can also leave behind bell characters or similar control bytes
+that the student never intended as part of the command.  We therefore
+normalise those details before checking plain string patterns.  Tutorials that
+truly need more control can opt into an explicit regular expression.
 
 <<constants>>=
 ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+CARET_CSI_RE = re.compile(r"\^\[\[[0-?]*[ -/]*[@-~]")
 WHITESPACE_RE = re.compile(r"\s+")
 @
 
@@ -1581,33 +1584,200 @@ def strip_terminal_controls(text: str) -> str:
     )
 @
 
+When scripted tests write escape bytes into the PTY before readline takes
+control, the transcript can contain caret-escaped CSI sequences such as
+[[^[[D]].  Converting those back into actual CSI bytes lets the rest of the
+normaliser replay both scripted and interactive transcripts with the same
+logic.
+
+<<functions>>=
+def expand_caret_csi_notation(text: str) -> str:
+    """Return ``text`` with caret-escaped CSI sequences restored."""
+
+    return CARET_CSI_RE.sub(
+        lambda match: "\x1b[" + match.group(0)[3:],
+        text,
+    )
+@
+
+We cannot simply strip every CSI sequence up front, because some of them are
+the edit itself: cursor-left, cursor-right, insert-character,
+delete-character, and erase-to-end change which characters remain visible on
+the line.  We therefore parse the small subset of CSI sequences that readline
+uses for line repair and ignore the rest as non-semantic terminal control.
+
+<<functions>>=
+def parse_csi_sequence(text: str, start: int) -> tuple[str, int] | None:
+    """Return one CSI sequence and the next index from ``start``."""
+
+    if not text.startswith("\x1b[", start):
+        return None
+
+    index = start + 2
+    while index < len(text):
+        if "@" <= text[index] <= "~":
+            return text[start : index + 1], index + 1
+        index += 1
+    return None
+@
+
+<<functions>>=
+def csi_count(parameter: str) -> int | None:
+    """Return the repeat count for one simple CSI parameter."""
+
+    if not parameter:
+        return 1
+    if parameter.isdigit():
+        return int(parameter)
+    return None
+@
+
+<<functions>>=
+def apply_csi_sequence(
+    line: list[str],
+    cursor: int,
+    sequence: str,
+) -> tuple[list[str], int]:
+    """Return ``(line, cursor)`` after replaying one CSI edit."""
+
+    parameter = sequence[2:-1]
+    final = sequence[-1]
+
+    if final == "C":
+        count = csi_count(parameter)
+        if count is not None:
+            return line, cursor + count
+        return line, cursor
+
+    if final == "D":
+        count = csi_count(parameter)
+        if count is not None:
+            return line, max(0, cursor - count)
+        return line, cursor
+
+    if final == "P":
+        count = csi_count(parameter)
+        if count is not None:
+            del line[cursor : cursor + count]
+        return line, cursor
+
+    if final == "@":
+        count = csi_count(parameter)
+        if count is not None:
+            line[cursor:cursor] = [" "] * count
+        return line, cursor
+
+    if final == "K" and parameter in {"", "0"}:
+        del line[cursor:]
+        return line, cursor
+
+    if final in {"F", "~"} and parameter in {"4"}:
+        return line, len(line)
+
+    if final in {"H", "~"} and parameter in {"", "1", "7"}:
+        return line, 0
+
+    return line, cursor
+@
+
+<<functions>>=
+def move_cursor_by_words(line: list[str], cursor: int, count: int, *, forward: bool) -> int:
+    """Return ``cursor`` moved by ``count`` shell-style word jumps."""
+
+    for _ in range(count):
+        if forward:
+            while cursor < len(line) and line[cursor].isspace():
+                cursor += 1
+            while cursor < len(line) and not line[cursor].isspace():
+                cursor += 1
+            continue
+
+        while cursor > 0 and line[cursor - 1].isspace():
+            cursor -= 1
+        while cursor > 0 and not line[cursor - 1].isspace():
+            cursor -= 1
+
+    return cursor
+@
+
+Modified-arrow and Alt-key motion matter because readline often redraws them as
+plain cursor movement plus insert operations.  Replaying shell-style word jumps
+keeps the cursor aligned with where the student actually inserted or deleted
+text, even when the original transcript only shows the raw control sequence.
+
 <<functions>>=
 def apply_line_editing(text: str) -> str:
-    """Return ``text`` after applying simple backspace-style edits."""
+    """Return ``text`` after replaying terminal line editing."""
 
-    characters = []
-    for character in text:
-        if character in {"\b", "\x7f"}:
-            if characters:
-                characters.pop()
+    text = expand_caret_csi_notation(text)
+    rendered = []
+    line = []
+    cursor = 0
+    index = 0
+    while index < len(text):
+        parsed = parse_csi_sequence(text, index)
+        if parsed is not None:
+            sequence, index = parsed
+            line, cursor = apply_csi_sequence(line, cursor, sequence)
             continue
-        characters.append(character)
-    return "".join(characters)
+
+        character = text[index]
+        index += 1
+
+        if character == "\x1b" and index < len(text):
+            next_character = text[index]
+            if next_character in {"b", "f"}:
+                index += 1
+                cursor = move_cursor_by_words(
+                    line,
+                    cursor,
+                    1,
+                    forward=next_character == "f",
+                )
+                continue
+
+        if character == "\r":
+            cursor = 0
+            continue
+        if character == "\n":
+            rendered.append("".join(line))
+            rendered.append("\n")
+            line = []
+            cursor = 0
+            continue
+        if character in {"\b", "\x7f"}:
+            cursor = max(0, cursor - 1)
+            continue
+        if ord(character) < 0x20 and character != "\t":
+            continue
+
+        if cursor > len(line):
+            line.extend(" " for _ in range(cursor - len(line)))
+        if cursor == len(line):
+            line.append(character)
+        else:
+            line[cursor] = character
+        cursor += 1
+
+    if line:
+        rendered.append("".join(line))
+    return "".join(rendered)
 @
 
 Readline redraw sequences matter here because a recorded backspace is not
-student-visible output; it only means the terminal overwrote the previous
-character.  Applying those edits after stripping ANSI sequences recovers the
-command the student actually left on screen.  We then drop any remaining
-control characters such as the bell byte from failed or partial tab
-completion, because those are terminal feedback rather than authored input.
+student-visible output; it only means the terminal moved the cursor before
+rewriting part of the line.  Replaying backspaces, carriage returns, and the
+relevant CSI edit operations recovers the command the student actually left on
+screen.  We then drop any remaining control characters such as the bell byte
+from failed or partial tab completion, because those are terminal feedback
+rather than authored input.
 
 <<functions>>=
 def normalise_recorded_text(text: str) -> str:
     """Return ``text`` without terminal control noise."""
 
-    text = ANSI_ESCAPE_RE.sub("", text)
     text = apply_line_editing(text)
+    text = ANSI_ESCAPE_RE.sub("", text)
     text = strip_terminal_controls(text)
     text = text.replace("\r", "\n")
     return text
@@ -1698,6 +1868,78 @@ def test_transcript_matches_patterns_ignores_tab_completion_bell():
             TextMatch("tutorial list --tutorial-path my-tutorials"),
             TextMatch("greeting"),
         ),
+    ) is True
+
+
+def test_transcript_matches_patterns_replays_cursor_left_insertions():
+    assert transcript_matches_patterns(
+        "echo hllo^[[D^[[D^[[De\r\n"
+        "exit\r\n"
+        "\x1b[?2004haudit $ echo hllo\b\b\bello\b\b\b\r\n"
+        "\x1b[?2004l\rhello\r\n"
+        "\x1b[?2004haudit $ exit\r\n"
+        "\x1b[?2004l\rexit\r\n",
+        (TextMatch("echo hello"), TextMatch("hello")),
+    ) is True
+
+
+def test_transcript_matches_patterns_replays_delete_key_edits():
+    assert transcript_matches_patterns(
+        "echo helllo^[[D^[[D^[[D^[[3~\r\n"
+        "exit\r\n"
+        "\x1b[?2004haudit $ echo helllo\b\b\b\x1b[C\x1b[1Po\b\b\r\n"
+        "\x1b[?2004l\rhello\r\n"
+        "\x1b[?2004haudit $ exit\r\n"
+        "\x1b[?2004l\rexit\r\n",
+        (TextMatch("echo hello"), TextMatch("hello")),
+    ) is True
+
+
+def test_transcript_matches_patterns_replays_alt_word_jumps():
+    assert transcript_matches_patterns(
+        "echo alph beta^[b^[b^[fa\r\n"
+        "exit\r\n"
+        "\x1b[?2004haudit $ echo alph beta\b\b\b\b\b\b\b\b\b"
+        "\x1b[C\x1b[C\x1b[C\x1b[Ca beta\b\b\b\b\b\r\n"
+        "\x1b[?2004l\ralpha beta\r\n"
+        "\x1b[?2004haudit $ exit\r\n"
+        "\x1b[?2004l\rexit\r\n",
+        (TextMatch("echo alpha beta"), TextMatch("alpha beta")),
+    ) is True
+
+
+def test_transcript_matches_patterns_replays_modified_arrow_word_jumps():
+    assert transcript_matches_patterns(
+        "echo alpha gamma^[[1;5D^[[1;5Dbeta \r\n"
+        "exit\r\n"
+        "\x1b[?2004haudit $ echo alpha gamma\b\b\b\b\b\b\b\b\b"
+        "\b\b\x1b[5@beta \r\n"
+        "\x1b[?2004l\rbeta alpha gamma\r\n"
+        "\x1b[?2004haudit $ exit\r\n"
+        "\x1b[?2004l\rexit\r\n",
+        (TextMatch("echo beta alpha gamma"), TextMatch("beta alpha gamma")),
+    ) is True
+
+
+def test_transcript_matches_patterns_replays_home_and_end_navigation():
+    assert transcript_matches_patterns(
+        "echo hello^[[F world\r\n"
+        "exit\r\n"
+        "\x1b[?2004haudit $ echo hello world\r\n"
+        "\x1b[?2004l\rhello world\r\n"
+        "\x1b[?2004haudit $ exit\r\n"
+        "\x1b[?2004l\rexit\r\n",
+        (TextMatch("echo hello world"), TextMatch("hello world")),
+    ) is True
+
+    assert transcript_matches_patterns(
+        "echo hello^[[4~ world\r\n"
+        "exit\r\n"
+        "\x1b[?2004haudit $ echo hello world\r\n"
+        "\x1b[?2004l\rhello world\r\n"
+        "\x1b[?2004haudit $ exit\r\n"
+        "\x1b[?2004l\rexit\r\n",
+        (TextMatch("echo hello world"), TextMatch("hello world")),
     ) is True
 
 

--- a/src/tutorial/run.nw
+++ b/src/tutorial/run.nw
@@ -1563,9 +1563,15 @@ delete operations, and the replacement characters that followed them.  That
 includes simple arrows, modified arrows such as Ctrl-Left and Ctrl-Right, and
 word-oriented motion such as Alt-b and Alt-f when readline redraws the line.
 Tab completion can also leave behind bell characters or similar control bytes
-that the student never intended as part of the command.  We therefore
-normalise those details before checking plain string patterns.  Tutorials that
-truly need more control can opt into an explicit regular expression.
+that the student never intended as part of the command.  Modern shells add a
+last layer on top of that: terminal-title and prompt-marker strings introduced
+by [[\x1b]]] (OSC) or [[\x1bP]] (DCS) bracket their payload between an
+introducer and a string terminator, keypad-mode flips such as [[\x1b=]] and
+[[\x1b>]] surround every prompt, and shells in application-cursor mode emit
+SS3 sequences such as [[\x1bOC]] in place of the more familiar CSI form.  We
+therefore normalise those details before checking plain string patterns.
+Tutorials that truly need more control can opt into an explicit regular
+expression.
 
 <<constants>>=
 ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
@@ -1632,6 +1638,21 @@ def csi_count(parameter: str) -> int | None:
     return None
 @
 
+Modifier-aware arrow keys carry the cursor position and the active modifier
+in a [[1;<mod>]] parameter.  Recognising that shape separately keeps
+[[csi_count]] focused on plain repeat counts while still letting
+[[apply_csi_sequence]] route Ctrl-arrow and Alt-arrow into word-jump motion.
+
+<<functions>>=
+def csi_modifier(parameter: str) -> int | None:
+    """Return the modifier value for ``\\x1b[1;<mod>`` style parameters."""
+
+    parts = parameter.split(";")
+    if len(parts) == 2 and parts[0] == "1" and parts[1].isdigit():
+        return int(parts[1])
+    return None
+@
+
 <<functions>>=
 def apply_csi_sequence(
     line: list[str],
@@ -1642,17 +1663,23 @@ def apply_csi_sequence(
 
     parameter = sequence[2:-1]
     final = sequence[-1]
+    modifier = csi_modifier(parameter)
+    word_modifiers = {3, 5, 7}
 
     if final == "C":
         count = csi_count(parameter)
         if count is not None:
             return line, cursor + count
+        if modifier in word_modifiers:
+            return line, move_cursor_by_words(line, cursor, 1, forward=True)
         return line, cursor
 
     if final == "D":
         count = csi_count(parameter)
         if count is not None:
             return line, max(0, cursor - count)
+        if modifier in word_modifiers:
+            return line, move_cursor_by_words(line, cursor, 1, forward=False)
         return line, cursor
 
     if final == "P":
@@ -1667,14 +1694,32 @@ def apply_csi_sequence(
             line[cursor:cursor] = [" "] * count
         return line, cursor
 
-    if final == "K" and parameter in {"", "0"}:
-        del line[cursor:]
+    if final == "K":
+        if parameter in {"", "0"}:
+            del line[cursor:]
+            return line, cursor
+        if parameter == "1":
+            del line[:cursor]
+            return line, 0
+        if parameter == "2":
+            line.clear()
+            return line, 0
         return line, cursor
 
-    if final in {"F", "~"} and parameter in {"4"}:
+    if final == "F":
+        if parameter in {"", "4"} or modifier is not None:
+            return line, len(line)
+        return line, cursor
+
+    if final == "H":
+        if parameter in {"", "1", "7"} or modifier is not None:
+            return line, 0
+        return line, cursor
+
+    if final == "~" and parameter == "4":
         return line, len(line)
 
-    if final in {"H", "~"} and parameter in {"", "1", "7"}:
+    if final == "~" and parameter in {"1", "7"}:
         return line, 0
 
     return line, cursor
@@ -1704,6 +1749,14 @@ Modified-arrow and Alt-key motion matter because readline often redraws them as
 plain cursor movement plus insert operations.  Replaying shell-style word jumps
 keeps the cursor aligned with where the student actually inserted or deleted
 text, even when the original transcript only shows the raw control sequence.
+Two more shapes share the same concern.  SS3 sequences ([[\x1bO]] followed by a
+single final byte) appear when the shell switches the keypad into application
+mode and arrow keys then emit [[\x1bOC]] / [[\x1bOD]] instead of CSI; without
+explicit handling the loop drops the [[\x1b]] but inserts the [[O]] and the
+final byte as content.  Likewise, two-byte ESC pairs such as [[\x1b=]],
+[[\x1b>]], [[\x1b7]], and [[\x1b8]] toggle keypad mode or save the cursor for
+later restoration; their second byte must be consumed alongside the [[\x1b]]
+or it leaks into the matched line.
 
 <<functions>>=
 def apply_line_editing(text: str) -> str:
@@ -1735,6 +1788,21 @@ def apply_line_editing(text: str) -> str:
                     forward=next_character == "f",
                 )
                 continue
+            if next_character == "O" and index + 1 < len(text):
+                ss3_final = text[index + 1]
+                index += 2
+                if ss3_final == "C":
+                    cursor = cursor + 1
+                elif ss3_final == "D":
+                    cursor = max(0, cursor - 1)
+                elif ss3_final == "H":
+                    cursor = 0
+                elif ss3_final == "F":
+                    cursor = len(line)
+                continue
+            if next_character in {"=", ">", "7", "8"}:
+                index += 1
+                continue
 
         if character == "\r":
             cursor = 0
@@ -1764,6 +1832,55 @@ def apply_line_editing(text: str) -> str:
     return "".join(rendered)
 @
 
+\subsection{Stripping string-terminated controls}
+
+OSC (Operating System Command) and DCS (Device Control String) sequences sit
+outside the CSI grammar that [[ANSI_ESCAPE_RE]] and [[apply_csi_sequence]]
+recognise: their payload runs between an introducer ([[\x1b]]] for OSC,
+[[\x1bP]] for DCS) and a string terminator (either [[\x07]] or [[\x1b\\]]),
+and the bytes in between can be arbitrary.  Modern terminals use them for
+window titles, FinalTerm/iTerm prompt markers, and OSC~8 hyperlinks, all of
+which are common in a student's prompt theme.  If we let those payloads reach
+[[apply_line_editing]], the [[\x1b]] is dropped as a control byte but the
+[[]]] or [[P]] and the rest of the payload are inserted as content, leaving
+fragments such as [[]0;hello]] in the matched text.  We therefore remove whole
+strings up front, before any line-edit replay.
+
+<<constants>>=
+OSC_DCS_RE = re.compile(r"\x1b[\]P][^\x07\x1b]*(?:\x07|\x1b\\)")
+@
+
+<<functions>>=
+def strip_string_terminators(text: str) -> str:
+    """Return ``text`` without OSC and DCS string-terminated sequences."""
+
+    return OSC_DCS_RE.sub("", text)
+@
+
+Let's verify that all three common string-terminated forms disappear, including
+the OSC~8 hyperlink which uses both an introducer-prefix and a separate close.
+
+<<test functions>>=
+def test_strip_string_terminators_removes_osc_and_dcs():
+    cleaned = strip_string_terminators(
+        "\x1b]0;tab title\x07start\x1b]133;A\x1b\\middle"
+        "\x1bPq sixel \x1b\\end"
+    )
+
+    assert cleaned == "startmiddleend"
+
+
+def test_strip_string_terminators_removes_osc_hyperlink_pair():
+    cleaned = strip_string_terminators(
+        "\x1b]8;;https://example.test\x07click\x1b]8;;\x07!"
+    )
+
+    assert cleaned == "click!"
+@
+
+
+\subsection{Composing the full normaliser}
+
 Readline redraw sequences matter here because a recorded backspace is not
 student-visible output; it only means the terminal moved the cursor before
 rewriting part of the line.  Replaying backspaces, carriage returns, and the
@@ -1772,10 +1889,17 @@ screen.  We then drop any remaining control characters such as the bell byte
 from failed or partial tab completion, because those are terminal feedback
 rather than authored input.
 
+The string-terminated scrubber runs first so OSC and DCS payloads never enter
+the line buffer; the line-edit replay then resolves the cursor-motion and
+edit-in-place CSI operations; the leftover non-edit CSI sequences (colours,
+mode toggles, cursor-position reports) are erased by [[ANSI_ESCAPE_RE]]; and
+[[strip_terminal_controls]] removes any final stray bytes such as the bell.
+
 <<functions>>=
 def normalise_recorded_text(text: str) -> str:
     """Return ``text`` without terminal control noise."""
 
+    text = strip_string_terminators(text)
     text = apply_line_editing(text)
     text = ANSI_ESCAPE_RE.sub("", text)
     text = strip_terminal_controls(text)
@@ -1948,6 +2072,86 @@ def test_transcript_matches_patterns_can_use_regex_mode():
         "tutorial run --restart shell-basics   \n",
         (TextMatch(r"tutorial run --restart shell-basics\s*", mode="regex"),),
     ) is True
+
+
+def test_transcript_matches_patterns_strips_osc_title_and_prompt_markers():
+    assert transcript_matches_patterns(
+        "\x1b]0;writing-tutorials\x07\x1b]133;A\x1b\\"
+        "\x1b[?2004hwriting-tutorials $ tutorial list\r\n"
+        "\x1b]133;C\x07\x1b[?2004l\rgreeting\r\n",
+        (
+            TextMatch("tutorial list"),
+            TextMatch("greeting"),
+        ),
+    ) is True
+
+
+def test_transcript_matches_patterns_strips_osc_hyperlink_payload():
+    assert transcript_matches_patterns(
+        "\x1b[?2004haudit $ open "
+        "\x1b]8;;https://example.test\x07docs\x1b]8;;\x07\r\n"
+        "\x1b[?2004l\ropened docs\r\n",
+        (TextMatch("open docs"), TextMatch("opened docs")),
+    ) is True
+
+
+def test_transcript_matches_patterns_ignores_keypad_mode_switches():
+    assert transcript_matches_patterns(
+        "\x1b=\x1b[?2004haudit $ echo hi\r\n"
+        "\x1b[?2004l\rhi\r\n\x1b>",
+        (TextMatch("echo hi"), TextMatch("hi")),
+    ) is True
+
+
+def test_transcript_matches_patterns_ignores_save_and_restore_cursor():
+    assert transcript_matches_patterns(
+        "\x1b7\x1b[?2004haudit $ echo hi\r\n"
+        "\x1b8\x1b[?2004l\rhi\r\n",
+        (TextMatch("echo hi"), TextMatch("hi")),
+    ) is True
+
+
+def test_transcript_matches_patterns_replays_ss3_arrow_navigation():
+    assert transcript_matches_patterns(
+        "echo hllo\x1bOD\x1bOD\x1bODe\r\n"
+        "exit\r\n"
+        "\x1b[?2004haudit $ echo hllo\b\b\bello\b\b\b\r\n"
+        "\x1b[?2004l\rhello\r\n",
+        (TextMatch("echo hello"), TextMatch("hello")),
+    ) is True
+
+
+def test_transcript_matches_patterns_replays_ctrl_arrow_word_jumps():
+    assert transcript_matches_patterns(
+        "echo alpha beta\x1b[1;5D\x1b[1;5DX\r\n"
+        "exit\r\n"
+        "\x1b[?2004haudit $ echo Xlpha beta\r\n"
+        "\x1b[?2004l\rXlpha beta\r\n",
+        (TextMatch("echo Xlpha beta"), TextMatch("Xlpha beta")),
+    ) is True
+    assert transcript_matches_patterns(
+        "echo alpha beta\x1b[1;5C\x1b[1;5C!\r\n",
+        (TextMatch("echo alpha beta"),),
+    ) is True
+
+
+def test_transcript_matches_patterns_handles_plain_csi_end_navigation():
+    assert transcript_matches_patterns(
+        "echo hello\x1b[F world\r\n"
+        "echo done\r\n",
+        (TextMatch("echo hello world"), TextMatch("echo done")),
+    ) is True
+
+
+def test_transcript_matches_patterns_replays_full_line_erase():
+    assert transcript_matches_patterns(
+        "echo wrong\r\x1b[2Kecho right\r\n",
+        (TextMatch("echo right"),),
+    ) is True
+    assert transcript_matches_patterns(
+        "echo wrong\r\x1b[2Kecho right\r\n",
+        (TextMatch("echo wrong"),),
+    ) is False
 @
 
 

--- a/src/tutorial/run.nw
+++ b/src/tutorial/run.nw
@@ -1559,13 +1559,26 @@ transcripts contain noise that students do not control: carriage returns,
 ANSI control sequences, and small whitespace differences from completion or
 line editing.  Some shells also record readline redraws literally, so one
 accepted command may appear as text, a backspace, and the replacement
-characters that followed it.  We therefore normalise those details before
-checking plain string patterns.  Tutorials that truly need more control can
-opt into an explicit regular expression.
+characters that followed it.  Tab completion can also leave behind bell
+characters or similar control bytes that the student never intended as part
+of the command.  We therefore normalise those details before checking plain
+string patterns.  Tutorials that truly need more control can opt into an
+explicit regular expression.
 
 <<constants>>=
 ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 WHITESPACE_RE = re.compile(r"\s+")
+@
+
+<<functions>>=
+def strip_terminal_controls(text: str) -> str:
+    """Return ``text`` without leftover non-printing terminal controls."""
+
+    return "".join(
+        character
+        for character in text
+        if character in {"\n", "\r", "\t"} or ord(character) >= 0x20
+    )
 @
 
 <<functions>>=
@@ -1585,7 +1598,9 @@ def apply_line_editing(text: str) -> str:
 Readline redraw sequences matter here because a recorded backspace is not
 student-visible output; it only means the terminal overwrote the previous
 character.  Applying those edits after stripping ANSI sequences recovers the
-command the student actually left on screen.
+command the student actually left on screen.  We then drop any remaining
+control characters such as the bell byte from failed or partial tab
+completion, because those are terminal feedback rather than authored input.
 
 <<functions>>=
 def normalise_recorded_text(text: str) -> str:
@@ -1593,6 +1608,7 @@ def normalise_recorded_text(text: str) -> str:
 
     text = ANSI_ESCAPE_RE.sub("", text)
     text = apply_line_editing(text)
+    text = strip_terminal_controls(text)
     text = text.replace("\r", "\n")
     return text
 @
@@ -1669,6 +1685,18 @@ def test_transcript_matches_patterns_ignores_line_redraw_backspaces():
             TextMatch("mkdir my-tutorials"),
             TextMatch("ls"),
             TextMatch("my-tutorials"),
+        ),
+    ) is True
+
+
+def test_transcript_matches_patterns_ignores_tab_completion_bell():
+    assert transcript_matches_patterns(
+        "\x1b[?2004hwriting-tutorials $ tutorial li\x07-\b\x1b[Kst --tutori"
+        "\x07al-path my-tutorials\r\n"
+        "\x1b[?2004l\r\x1b[1mgreeting         \x1b[0m 0/1 complete\r\n",
+        (
+            TextMatch("tutorial list --tutorial-path my-tutorials"),
+            TextMatch("greeting"),
         ),
     ) is True
 

--- a/src/tutorial/tutorials/using-tutorials.md
+++ b/src/tutorial/tutorials/using-tutorials.md
@@ -37,7 +37,8 @@ Run `tutorial run --restart shell-basics`.
 
 The `run` command starts or resumes saved work. We use `--restart` here so
 this step behaves the same way even if you have already finished
-`shell-basics` before.
+`shell-basics` before. `--restart` discards every saved transcript for that
+tutorial, not just the step you are about to revisit.
 
 Because this lesson is already running, the nested shell prompt changes to
 `shell-basics $ ` so you can tell which tutorial owns the current shell.
@@ -168,9 +169,44 @@ session is still in progress, the review output can show the earlier saved
 steps, but it cannot show this step until after you exit the shell and the
 step is recorded.
 
-At this point you have seen the tutorial workflow end to end:
+At this point you have seen the main run-and-review workflow end to end:
 
 - `tutorial list` discovers what you can run
 - `tutorial run` starts or resumes one tutorial at a time
 - question steps can ask for input, one choice, or several choices
 - `tutorial review` inspects the saved record afterwards
+
+# Inspect one step of the saved run
+
+```tutorial-step
+required_patterns:
+  - tutorial review using-tutorials --step 1
+  - "Step 1: List the available tutorials"
+hint: Review only step 1 from inside this shell.
+```
+
+Run `tutorial review using-tutorials --step 1`.
+
+`--step N` narrows the review to one 1-indexed step instead of the whole
+run. Review normally shows the latest saved run for that tutorial; use
+`--run-id <id>` to pick an older one instead. `tutorial review --help`
+shows the full form.
+
+# Install a tutorial from a file or URL
+
+```tutorial-step
+kind: input
+answers:
+  - mode: regex
+    pattern: ^tutorial\s+install\s+\S+(?:\s+--force)?\s*$
+hint: Type an install command with a file path or URL.
+```
+
+Type a command such as `tutorial install ./lesson.md` or
+`tutorial install https://example.com/lesson.md --force`.
+
+`tutorial install <source>` copies a tutorial Markdown file into your
+installed tutorial directory so it appears in `tutorial list` alongside the
+built-ins. Add `--force` to overwrite an installed tutorial with the same
+`id`. This question step only records your answer, so you can practice the
+command safely without installing anything.

--- a/src/tutorial/tutorials/writing-tutorials.md
+++ b/src/tutorial/tutorials/writing-tutorials.md
@@ -130,6 +130,37 @@ part of the transcript should match.
 Use regex when you need that extra control. Otherwise, keep the shorter
 string form.
 
+# Match shell output with a regex
+
+```tutorial-step
+edit_file: my-tutorials/greeting.md
+required_patterns:
+  - "required_patterns:"
+  - "  - mode: regex"
+  - "    pattern: (?m)^hello$"
+```
+
+Keep the same tutorial file, the same step title, and the same
+`echo hello` command, but change the regex so it matches the output line
+instead of the command line:
+
+````md
+# Say hello
+
+```tutorial-step
+required_patterns:
+  - mode: regex
+    pattern: (?m)^hello$
+```
+
+Run `echo hello`.
+````
+
+`(?m)` lets `^` and `$` mean line boundaries inside the recorded shell
+transcript. That is where regex starts to earn its keep: `contains` can
+only say that `hello` appears somewhere, while this rule matches one whole
+line of shell output.
+
 # Add an editor-backed step
 
 ```tutorial-step
@@ -157,7 +188,8 @@ Open `hello.txt` and add `hello from the editor`.
 This now contrasts two different step backends in the same tutorial: a
 shell step with explicit matching metadata and an editor-backed step with
 `edit_file`. `edit_file` still selects the editor backend, while question
-steps use `kind`.
+steps use `kind`. `edit_file` and `kind` are mutually exclusive, so
+combining them is a parse-time error.
 
 # Add an input question
 
@@ -266,6 +298,38 @@ Multi-select questions also use literal YAML lists. The learner may choose
 the correct options in any order, but authors still list the correct
 option texts explicitly under `answers`.
 
+# Add a shell check to the editor step
+
+```tutorial-step
+edit_file: my-tutorials/greeting.md
+required_patterns:
+  - "check_command:"
+  - 'test "$(cat hello.txt)" = "hello from the editor"'
+```
+
+Keep the same `# Edit a note` step, but add a filesystem-based shell check:
+
+````md
+# Edit a note
+
+```tutorial-step
+edit_file: hello.txt
+required_patterns:
+  - hello from the editor
+check_command: test "$(cat hello.txt)" = "hello from the editor"
+```
+
+Open `hello.txt` and add `hello from the editor`.
+````
+
+`check_command` is opt-in. The runner refuses to execute it unless the
+reader passes `--allow-shell-checks`. It runs in a separate
+`/bin/bash -lc` process with the tutorial workspace as its current
+directory, so it can inspect files there but it does not inherit shell
+variables or other session state from the interactive step. It is also
+AND-ed with `required_patterns`: both checks must pass before the step
+completes.
+
 # Test the tutorial you wrote
 
 ```tutorial-step
@@ -295,6 +359,33 @@ For this step:
 3. The nested run should report `Step not complete yet: Say hello`.
 4. Exit this lesson's shell too so the transcript is recorded.
 
+# Iterate on one step with `tutorial develop`
+
+```tutorial-step
+required_patterns:
+  - tutorial develop --tutorial-path my-tutorials greeting 1
+  - "greeting $"
+  - "Verdict: FAIL"
+hint: Start develop for step 1, exit immediately, then keep the FAIL verdict and stop.
+```
+
+Run `tutorial develop --tutorial-path my-tutorials greeting 1`.
+
+For this step:
+
+1. Run `tutorial develop --tutorial-path my-tutorials greeting 1`.
+2. When the temporary `greeting $ ` shell opens, type `exit` immediately.
+3. Answer yes when `tutorial develop` asks whether the `FAIL` verdict is
+   correct.
+4. Answer no when it asks whether to run the step again.
+
+`tutorial develop` exercises one authored step in a temporary workspace,
+prints `PASS` or `FAIL`, and lets you edit and re-run that step without
+restarting the whole tutorial. We point at step `1` by number here, but the
+same command also accepts a regex that matches the step title. Develop also
+enables shell checks by default; pass `--deny-shell-checks` to turn them
+off for one session.
+
 # Inspect the finished tutorial
 
 ```tutorial-step
@@ -302,10 +393,12 @@ required_patterns:
   - tutorial list --tutorial-path my-tutorials
   - greeting
   - cat my-tutorials/greeting.md
+  - "    pattern: (?m)^hello$"
   - "kind: input"
   - "kind: single_select"
   - "kind: multi_select"
   - "edit_file: hello.txt"
+  - 'check_command: test "$(cat hello.txt)" = "hello from the editor"'
   - "    pattern: (?i)hello(?:\\s+)?$"
 hint: List the tutorials, then display the file you wrote.
 ```
@@ -318,4 +411,4 @@ At this point you have checked the same tutorial in three different ways:
 - `tutorial list --tutorial-path my-tutorials` shows that it loads
 - `tutorial run --tutorial-path my-tutorials greeting` shows that it runs
 - `cat my-tutorials/greeting.md` lets you inspect the final shell, editor,
-  and question metadata directly
+  shell-check, and question metadata directly

--- a/src/tutorial/tutorials/writing-tutorials.md
+++ b/src/tutorial/tutorials/writing-tutorials.md
@@ -104,7 +104,7 @@ edit_file: my-tutorials/greeting.md
 required_patterns:
   - "required_patterns:"
   - "  - mode: regex"
-  - '    pattern: (?m)echo hello(?:\\s+)?$'
+  - '    pattern: (?m)echo hello(?:\s+)?$'
 ```
 
 Keep the same tutorial, the same step title, and the same command, but


### PR DESCRIPTION
- **Add `develop` command for iterative step authoring**
- **Align tutorial lessons with CLI**
- **Ignore fenced headings in tutorial parser**
- **Fix tutorial review and lesson regex**
- **Ignore shell redraw noise in transcripts**
- **Ignore tab-completion noise in transcripts**
- **Replay cursor navigation in transcripts**
- **Strip OSC, DCS, SS3, and keypad escapes from transcripts**
