### PR TITLE
Improve tutorial CLI guidance

### DIFF
--- a/src/pytorial/tutorials/shell-basics.nw
+++ b/src/pytorial/tutorials/shell-basics.nw
@@ -55,7 +55,7 @@ directory, so [[pwd]] is meaningful.
 required_patterns:
   - pwd
   - ls
-hint: The shell starts in the tutorial workspace.
+hint: "Two questions, two commands: where am I, and what is here?"
 ```
 
 Run `pwd` and `ls`.
@@ -82,7 +82,7 @@ required_patterns:
   - mkdir notes
   - ls
   - notes
-hint: Create a directory called `notes`, then list the workspace again.
+hint: "Create a directory and confirm it exists --- both halves matter for the step to pass."
 ```
 
 Create a directory named `notes`, then run `ls` again.
@@ -109,7 +109,7 @@ required_patterns:
   - touch notes/todo.md
   - ls notes
   - todo.md
-hint: Use `touch` with the nested path `notes/todo.md`.
+hint: "Same path stem, different leaf: the directory becomes a container for the file you create inside it."
 ```
 
 Create `notes/todo.md`, then run `ls notes`.
@@ -137,6 +137,7 @@ edit_file: notes/todo.md
 required_patterns:
   - tutorial authoring
   - remember this path
+hint: "Two short fragments --- the validator only checks that both appear somewhere in the saved file, so wrap the lines however you like."
 ```
 
 Open `notes/todo.md` in your editor and add two short lines:
@@ -171,7 +172,7 @@ required_patterns:
   - todo.md
   - cat notes/todo.md
   - tutorial authoring
-hint: First list the directory, then display the file.
+hint: "Two complementary views of the same data: one enumerates, the other reveals contents."
 ```
 
 Run `ls notes` and `cat notes/todo.md`.
@@ -201,7 +202,7 @@ required_patterns:
   - touch my-tutorials/demo.md
   - ls my-tutorials
   - demo.md
-hint: Repeat the same directory-and-file pattern with new names.
+hint: "Same pattern, new names --- directory first, then a file inside it."
 ```
 
 Create a directory named `my-tutorials`, create

--- a/src/pytorial/tutorials/using-tutorials.nw
+++ b/src/pytorial/tutorials/using-tutorials.nw
@@ -76,17 +76,18 @@ detail surfaces, and it matters for users who script around the CLI.
 
 ```tutorial-step
 required_patterns:
-  - tutorial list
+  - mode: regex
+    pattern: (?:^|\s)(?:tutorial|pytorial)\s+list\b
   - using-tutorials
   - shell-basics
   - writing-tutorials
-hint: Run `tutorial list`.
+hint: "One verb prints the catalog of installed tutorials --- its name says what it does."
 ```
 
-Run `tutorial list`.
+Use the **list** verb.
 
-In a terminal, `tutorial list` renders a readable table. When the same
-command is piped into a script, it switches to tab-separated rows.
+In a terminal, the **list** verb renders a readable table. When the
+same output is piped into a script, it switches to tab-separated rows.
 
 Its main job is to show which tutorials are available and how much
 progress is already saved for each one.
@@ -124,25 +125,27 @@ workflow.
 
 ```tutorial-step
 required_patterns:
-  - tutorial run --restart shell-basics
+  - mode: regex
+    pattern: (?:^|\s)(?:tutorial|pytorial)\s+run\s+--restart\s+shell-basics\b
   - "shell-basics $"
   - "Step not complete yet: Inspect the workspace"
-hint: Start `shell-basics`, then leave its first shell with `exit`.
+hint: "Start `shell-basics` from scratch (one flag forces a clean run), then leave its first shell without doing what it asks."
 ```
 
-Run `tutorial run --restart shell-basics`.
+Use the **run** verb with `--restart` to start `shell-basics`.
 
-The `run` command starts or resumes saved work. We use `--restart` here so
-this step behaves the same way even if you have already finished
-`shell-basics` before. `--restart` discards every saved transcript for that
-tutorial, not just the step you are about to revisit.
+The **run** verb starts or resumes saved work. We use `--restart`
+here so this step behaves the same way even if you have already
+finished `shell-basics` before. `--restart` discards every saved
+transcript for that tutorial, not just the step you are about to
+revisit.
 
 Because this lesson is already running, the nested shell prompt changes to
 `shell-basics $ ` so you can tell which tutorial owns the current shell.
 
 For this step:
 
-1. Run `tutorial run --restart shell-basics`.
+1. Start `shell-basics` with the **run** verb and the `--restart` flag.
 2. When the nested shell opens, type `exit`.
 3. After the nested command reports that the step is not complete yet,
    exit this outer shell too.
@@ -170,7 +173,7 @@ required_patterns:
   - "using-tutorials $"
   - pwd
   - ls
-hint: First exit after `pwd`, then choose `try again` and run both commands.
+hint: "Two passes: feel the not-complete message after a partial attempt, then take the runner's retry offer and finish every command the step requires."
 ```
 
 Now return to this tutorial's own shell.
@@ -182,8 +185,8 @@ To feel how step validation works, try this step in two rounds:
 3. Choose `try again`, run both `pwd` and `ls`, then exit again.
 
 Only the latest recorded attempt counts. If you leave now and come back
-later, `tutorial run using-tutorials` resumes from the first unfinished
-step unless you restart it.
+later, the **run** verb resumes from the first unfinished step unless
+you restart it.
 @
 
 \section{Step 4: Capture the workflow in a file}
@@ -204,16 +207,17 @@ mistakenly inferring that the runner is shell-only.
 ```tutorial-step
 edit_file: tutorial-commands.txt
 required_patterns:
-  - tutorial list discovers tutorials
-  - tutorial run starts or resumes one
-  - tutorial review shows saved transcripts
+  - list discovers tutorials
+  - run starts or resumes one
+  - review shows saved transcripts
+hint: "Each line names one verb and what it is for --- focus on the role, not on how to spell the command."
 ```
 
 Open `tutorial-commands.txt` in your editor and add these three lines:
 
-- `tutorial list discovers tutorials`
-- `tutorial run starts or resumes one`
-- `tutorial review shows saved transcripts`
+- `list discovers tutorials`
+- `run starts or resumes one`
+- `review shows saved transcripts`
 
 Save the file and quit the editor.
 
@@ -225,13 +229,14 @@ finish the step.
 \section{Step 5: Answer a one-line question}
 
 This is the smallest question step possible: [[kind: input]] with a
-single regex answer.  The regex anchors on whitespace
-([[(?:\s+)?\$]]) so trailing spaces from terminal autocomplete do not
-fail the match.  We chose regex rather than a [[contains]] string for
-this introduction so the learner sees the more powerful answer mode
-first; the next two steps then \emph{contrast} with bare-string
-answers, which makes the difference between answer modes legible
-through variation rather than through direct explanation.
+single regex answer.  The regex accepts either bare [[tutorial]] /
+[[pytorial]] commands or a one-token host prefix followed by one of
+those names.  It still tolerates trailing whitespace so terminal
+autocomplete does not fail the match.  We chose regex rather than a
+[[contains]] string for this introduction so the learner sees the more
+powerful answer mode first; the next two steps then \emph{contrast}
+with bare-string answers, which makes the difference between answer
+modes legible through variation rather than through direct explanation.
 
 <<input question step>>=
 # Answer a one-line question
@@ -240,12 +245,11 @@ through variation rather than through direct explanation.
 kind: input
 answers:
   - mode: regex
-    pattern: ^tutorial\s+review\s+using-tutorials(?:\s+)?$
-hint: Type the full review command for this tutorial.
+    pattern: ^(\S+\s+)?(?:tutorial|pytorial)\s+review\s+using-tutorials\s*$
+hint: "Which verb reads saved transcripts? Pair it with the id of the tutorial you are inside right now."
 ```
 
-Type the exact command that reviews this tutorial:
-`tutorial review using-tutorials`.
+Type the exact command that reviews this tutorial.
 
 This is the smallest question step. The tutorial asks for one line of
 text, records it immediately, and validates it without opening a shell.
@@ -267,14 +271,15 @@ text form so authors do not have to track positions.
 ```tutorial-step
 kind: single_select
 options:
-  - tutorial list
-  - tutorial run
-  - tutorial review
+  - list
+  - run
+  - review
 answers:
-  - tutorial run
+  - run
+hint: "Look for the verb whose job is to begin or resume work, not to inspect it."
 ```
 
-Choose the command that starts or resumes one tutorial.
+Choose the verb that starts or resumes one tutorial.
 
 Single-select questions show numbered options. You can answer with the
 number or with the full option text.
@@ -297,17 +302,17 @@ read-versus-write semantics.
 ```tutorial-step
 kind: multi_select
 options:
-  - tutorial list
-  - tutorial run
-  - tutorial review
-  - tutorial install
+  - list
+  - run
+  - review
+  - install
 answers:
-  - tutorial list
-  - tutorial review
-hint: Choose the commands that only read tutorial definitions or saved state.
+  - list
+  - review
+hint: "Pick the verbs that only read --- they neither start a run nor mutate what is installed."
 ```
 
-Choose every tutorial command here that reads existing information without
+Choose every verb here that reads existing information without
 starting a run or installing anything.
 
 Multi-select questions also use literal option text. The learner may pick
@@ -335,16 +340,17 @@ fuse them into a single mental model.
 
 ```tutorial-step
 required_patterns:
-  - tutorial review using-tutorials
+  - mode: regex
+    pattern: (?:^|\s)(?:tutorial|pytorial)\s+review\s+using-tutorials\b
   - Using Tutorials
   - "Step 1: List the available tutorials"
   - "Step 4: Capture the workflow in a file"
   - "Step 7: Pick every read-only tutorial command"
-  - tutorial review shows saved transcripts
-hint: Review `using-tutorials` from inside this shell.
+  - review shows saved transcripts
+hint: "Use the read-only verb on this very tutorial --- and stay inside the current shell so the run is still in progress when you read it back."
 ```
 
-Run `tutorial review using-tutorials`.
+Use the **review** verb on `using-tutorials`.
 
 Review reads the saved transcripts for the current run. Because this shell
 session is still in progress, the review output can show the earlier saved
@@ -353,10 +359,10 @@ step is recorded.
 
 At this point you have seen the main run-and-review workflow end to end:
 
-- `tutorial list` discovers what you can run
-- `tutorial run` starts or resumes one tutorial at a time
+- `list` discovers what you can run
+- `run` starts or resumes one tutorial at a time
 - question steps can ask for input, one choice, or several choices
-- `tutorial review` inspects the saved record afterwards
+- `review` inspects the saved record afterwards
 @
 
 \section{Step 9: Inspect one step of the saved run}
@@ -376,16 +382,17 @@ tutorial.
 
 ```tutorial-step
 required_patterns:
-  - tutorial review using-tutorials --step 1
+  - mode: regex
+    pattern: (?:^|\s)(?:tutorial|pytorial)\s+review\s+using-tutorials\s+--step\s+1\b
   - "Step 1: List the available tutorials"
-hint: Review only step 1 from inside this shell.
+hint: "One flag narrows the review to a single step; combine it with the right index."
 ```
 
-Run `tutorial review using-tutorials --step 1`.
+Use the **review** verb with `--step 1`.
 
 `--step N` narrows the review to one 1-indexed step instead of the whole
 run. Review normally shows the latest saved run for that tutorial; use
-`--run-id <id>` to pick an older one instead. `tutorial review --help`
+`--run-id <id>` to pick an older one instead. The help for **review**
 shows the full form.
 @
 
@@ -395,11 +402,12 @@ shows the full form.
 real --- running it would mutate the user's installed tutorial
 directory and pollute later [[tutorial list]] output, including
 output the same tutorial validates against.  The compromise is to
-make the step a [[kind: input]] question whose regex accepts any
-[[tutorial install <source>]] form, with optional [[--force]].  The
-learner types the command shape without it being run.  This still
-teaches the verb, the argument shape, and the [[--force]] override
-semantics, while keeping the rest of the tutorial reproducible.
+make the step a [[kind: input]] question whose regex accepts either
+the standalone names or a one-token host prefix, followed by
+[[install <source>]] with optional [[--force]].  The learner types
+the command shape without it being run.  This still teaches the verb,
+the argument shape, and the [[--force]] override semantics, while
+keeping the rest of the tutorial reproducible.
 
 <<install step>>=
 # Install a tutorial from a file or URL
@@ -408,16 +416,16 @@ semantics, while keeping the rest of the tutorial reproducible.
 kind: input
 answers:
   - mode: regex
-    pattern: ^tutorial\s+install\s+\S+(?:\s+--force)?\s*$
-hint: Type an install command with a file path or URL.
+    pattern: ^(\S+\s+)?(?:tutorial|pytorial)\s+install\s+\S+(?:\s+--force)?\s*$
+hint: "The install verb takes one positional source --- local path or URL --- with an optional override flag."
 ```
 
-Type a command such as `tutorial install ./lesson.md` or
-`tutorial install https://example.com/lesson.md --force`.
+Type an install invocation such as `install ./lesson.md` or
+`install <URL> --force`.
 
-`tutorial install <source>` copies a tutorial Markdown file into your
-installed tutorial directory so it appears in `tutorial list` alongside the
-built-ins. Add `--force` to overwrite an installed tutorial with the same
-`id`. This question step only records your answer, so you can practice the
-command safely without installing anything.
+The **install** verb copies a tutorial Markdown file into your
+installed tutorial directory so it appears in the catalog alongside the
+built-ins. Add `--force` to overwrite an installed tutorial with the
+same `id`. This question step only records your answer, so you can
+practice the command safely without installing anything.
 @

--- a/src/pytorial/tutorials/writing-tutorials.nw
+++ b/src/pytorial/tutorials/writing-tutorials.nw
@@ -88,7 +88,7 @@ required_patterns:
   - mkdir my-tutorials
   - ls
   - my-tutorials
-hint: Create `my-tutorials`, then list the workspace.
+hint: "Make the directory the rest of the lesson will write into, then confirm it appeared in the listing."
 ```
 
 Create a directory named `my-tutorials`, then run `ls`.
@@ -120,6 +120,7 @@ required_patterns:
   - "summary: A tiny tutorial for saying hello."
   - "# Say hello"
   - echo hello
+hint: "Three required front-matter fields, then one heading-introduced step whose only line is a shell command --- the smallest tutorial that loads."
 ```
 
 Open `my-tutorials/greeting.md` and write this tutorial:
@@ -159,12 +160,13 @@ invariant breaks.
 
 ```tutorial-step
 required_patterns:
-  - tutorial list --tutorial-path my-tutorials
+  - mode: regex
+    pattern: (?:^|\s)(?:tutorial|pytorial)\s+list\s+--tutorial-path\s+my-tutorials\b
   - greeting
-hint: Point the standalone CLI at `my-tutorials`.
+hint: "List the catalog, but tell it to look at your custom directory instead of only the built-ins."
 ```
 
-Run `tutorial list --tutorial-path my-tutorials`.
+Use the **list** verb with `--tutorial-path my-tutorials`.
 
 If the file parses, `greeting` should appear in the list.
 @
@@ -189,6 +191,7 @@ required_patterns:
   - "```tutorial-step"
   - "required_patterns:"
   - "  - echo hello"
+hint: "Insert a metadata fence above the instructions and add one bare-string rule that names the command in the step."
 ```
 
 Keep the same tutorial and the same step, but add a metadata fence before
@@ -236,6 +239,7 @@ required_patterns:
   - "required_patterns:"
   - "  - mode: regex"
   - '    pattern: (?m)echo hello(?:\s+)?$'
+hint: "Same step, same command --- only the rule changes from a bare string to a regex mapping with `mode` and `pattern` keys."
 ```
 
 Keep the same tutorial, the same step title, and the same command, but
@@ -283,6 +287,7 @@ required_patterns:
   - "required_patterns:"
   - "  - mode: regex"
   - "    pattern: (?m)^hello$"
+hint: "Different target this time: the regex anchors on the output line, not the typed command. Do not forget the multi-line flag."
 ```
 
 Keep the same tutorial file, the same step title, and the same
@@ -327,6 +332,7 @@ required_patterns:
   - "# Edit a note"
   - "edit_file: hello.txt"
   - hello from the editor
+hint: "Add a second top-level heading with `edit_file:` and a fragment of the saved text. No `kind` --- those two are mutually exclusive."
 ```
 
 Add this second step to the same file:
@@ -371,6 +377,7 @@ required_patterns:
   - "answers:"
   - "  - mode: regex"
   - "    pattern: (?i)hello(?:\\s+)?$"
+hint: "Switch the interaction with `kind: input` and reuse the same string-or-regex shape under `answers:`."
 ```
 
 Add this third step to the same file:
@@ -417,6 +424,7 @@ required_patterns:
   - "  - ls"
   - "answers:"
   - "  - echo hello"
+hint: "List the option labels under `options:` and the correct one --- by text, not number --- under `answers:`."
 ```
 
 Add this fourth step to the same file:
@@ -468,6 +476,7 @@ required_patterns:
   - "answers:"
   - "  - pwd"
   - "  - ls"
+hint: "Same shape as single-select, but more than one entry under `answers:`."
 ```
 
 Add this fifth step to the same file:
@@ -522,6 +531,7 @@ edit_file: my-tutorials/greeting.md
 required_patterns:
   - "check_command:"
   - 'test "$(cat hello.txt)" = "hello from the editor"'
+hint: "Add `check_command:` alongside the existing rules --- one line of shell that tests the saved file."
 ```
 
 Keep the same `# Edit a note` step, but add a filesystem-based shell check:
@@ -565,6 +575,7 @@ edit_file: my-tutorials/greeting.md
 required_patterns:
   - "pre_command: export GREETING_TARGET=world"
   - "echo hello \"$GREETING_TARGET\""
+hint: "Add `pre_command:` to set up an environment variable, then reference it in the step's command."
 ```
 
 Keep the same `# Say hello` step, but add hidden shell setup:
@@ -604,6 +615,7 @@ required_patterns:
   - "  mkdir -p setup"
   - "  cd setup"
   - "  printf 'world\\n' > target.txt"
+hint: "Use YAML `|` so all lines run as one bash process; one line should `cd`, another should write the file the command reads."
 ```
 
 Keep the same `# Say hello` step, but replace the single-line setup with this
@@ -643,6 +655,7 @@ to fix.
 edit_file: my-tutorials/greeting.md
 required_patterns:
   - "post_command: rm -f setup/target.txt"
+hint: "Cleanup runs only on success --- place it after the existing rules so the workspace stays inspectable on failure."
 ```
 
 Keep the same `# Say hello` step, but add cleanup after validation passes:
@@ -689,21 +702,23 @@ treatment of [[--restart]].
 
 ```tutorial-step
 required_patterns:
-  - tutorial run --allow-shell --tutorial-path my-tutorials greeting
+  - mode: regex
+    pattern: (?:^|\s)(?:tutorial|pytorial)\s+run\s+--allow-shell\s+--tutorial-path\s+my-tutorials\s+greeting\b
   - "greeting $"
   - "Step not complete yet: Say hello"
-hint: Start `greeting`, then leave its first shell with `exit`.
+hint: "Run your authored tutorial, but the standalone CLI demands you trust the hooks you wrote. Leave the first step's shell before doing what it asks."
 ```
 
-Run `tutorial run --allow-shell --tutorial-path my-tutorials greeting`.
+Use the **run** verb with `--allow-shell --tutorial-path my-tutorials greeting`.
 
-This still tests a different aspect from `tutorial list --tutorial-path
-my-tutorials`. Listing only proves that the file parses and the tutorial is
-discoverable. Running it proves that the authored tutorial still starts
-with the expected shell backend even after you add editor and question
-steps later in the file. By this point the tutorial also contains
-`pre_command`, `check_command`, and `post_command`, so standalone `run`
-must be told to trust those hooks explicitly.
+This still tests a different aspect from the **list** verb with
+`--tutorial-path my-tutorials`. Listing only proves that the file
+parses and the tutorial is discoverable. Running it proves that the
+authored tutorial still starts with the expected shell backend even
+after you add editor and question steps later in the file. By this
+point the tutorial also contains `pre_command`, `check_command`, and
+`post_command`, so standalone `run` must be told to trust those hooks
+explicitly.
 
 Keep the tutorial file itself invariant here. Only the command changes: you
 now move from inspecting tutorial metadata to exercising the authored
@@ -711,7 +726,8 @@ behaviour.
 
 For this step:
 
-1. Run `tutorial run --allow-shell --tutorial-path my-tutorials greeting`.
+1. Start `greeting` with the **run** verb plus
+   `--allow-shell --tutorial-path my-tutorials`.
 2. When the nested shell opens with the `greeting $ ` prompt, type `exit`.
 3. The nested run should report `Step not complete yet: Say hello`.
 4. Exit this lesson's shell too so the transcript is recorded.
@@ -738,15 +754,16 @@ the refusal line stands in as the proof that the gate ran first.
 
 ```tutorial-step
 required_patterns:
-  - tutorial run --tutorial-path my-tutorials greeting
+  - mode: regex
+    pattern: (?:^|\s)(?:tutorial|pytorial)\s+run\s+--tutorial-path\s+my-tutorials\s+greeting\b
   - Tutorial shell hooks and validation are disabled
-hint: Run the same command from step 15, but omit `--allow-shell`.
+hint: "Re-run the same target, but drop the trust flag and watch what happens before the shell even opens."
 ```
 
 Predict what changes when you drop `--allow-shell` from the run command
 you used in step 15.
 
-Run `tutorial run --tutorial-path my-tutorials greeting`.
+Use the same **run** invocation from step 15 without `--allow-shell`.
 
 Only the trust flag varies. The same tutorial file, the same target
 step, and the same nested-shell command from step 15 stay invariant.
@@ -785,28 +802,28 @@ their tutorials is the kind that bites people who do not know about it.
 
 ```tutorial-step
 required_patterns:
-  - tutorial develop --tutorial-path my-tutorials greeting 1
+  - mode: regex
+    pattern: (?:^|\s)(?:tutorial|pytorial)\s+develop\s+--tutorial-path\s+my-tutorials\s+greeting\s+1\b
   - "greeting $"
   - "Verdict: FAIL"
-hint: Start develop for step 1, exit immediately, then keep the FAIL verdict and stop.
+hint: "Drive `develop` against step 1, exit immediately to force a verdict, accept it, then decline to iterate."
 ```
 
-Run `tutorial develop --tutorial-path my-tutorials greeting 1`.
+Use `develop` on step `1` with `--tutorial-path my-tutorials greeting`.
 
 For this step:
 
-1. Run `tutorial develop --tutorial-path my-tutorials greeting 1`.
+1. Start `develop` for step `1` with `--tutorial-path my-tutorials greeting`.
 2. When the temporary `greeting $ ` shell opens, type `exit` immediately.
-3. Answer yes when `tutorial develop` asks whether the `FAIL` verdict is
-   correct.
+3. Answer yes when `develop` asks whether the `FAIL` verdict is correct.
 4. Answer no when it asks whether to run the step again.
 
-`tutorial develop` exercises one authored step in a temporary workspace,
-prints `PASS` or `FAIL`, and lets you edit and re-run that step without
-restarting the whole tutorial. We point at step `1` by number here, but the
-same command also accepts a regex that matches the step title. Develop also
-enables shell code by default; pass `--no-allow-shell` to turn it off for one
-session.
+`develop` exercises one authored step in a temporary workspace, prints
+`PASS` or `FAIL`, and lets you edit and re-run that step without
+restarting the whole tutorial. We point at step `1` by number here,
+but the same command also accepts a regex that matches the step title.
+Develop also enables shell code by default; pass `--no-allow-shell` to
+turn it off for one session.
 @
 
 \section{Step 18: Inspect the finished tutorial}
@@ -830,7 +847,8 @@ its review step.
 
 ```tutorial-step
 required_patterns:
-  - tutorial list --tutorial-path my-tutorials
+  - mode: regex
+    pattern: (?:^|\s)(?:tutorial|pytorial)\s+list\s+--tutorial-path\s+my-tutorials\b
   - greeting
   - cat my-tutorials/greeting.md
   - "    pattern: (?m)^hello$"
@@ -842,17 +860,19 @@ required_patterns:
   - 'check_command: test "$(cat hello.txt)" = "hello from the editor"'
   - "post_command: rm -f setup/target.txt"
   - "    pattern: (?i)hello(?:\\s+)?$"
-hint: List the tutorials, then display the file you wrote.
+hint: "Two views of the same artefact: what the catalog sees, and what is on disk."
 ```
 
-Run `tutorial list --tutorial-path my-tutorials` and
+Use the **list** verb with `--tutorial-path my-tutorials`, then run
 `cat my-tutorials/greeting.md`.
 
 At this point you have checked the same tutorial in four different ways:
 
-- `tutorial list --tutorial-path my-tutorials` shows that it loads
-- `tutorial run --allow-shell --tutorial-path my-tutorials greeting` shows that it runs once shell hooks are trusted
-- `tutorial run --tutorial-path my-tutorials greeting` (without `--allow-shell`) shows the standalone trust gate refusing untrusted hook code
+- `list --tutorial-path my-tutorials` shows that it loads
+- `run --allow-shell --tutorial-path my-tutorials greeting` shows that
+  it runs once shell hooks are trusted
+- `run --tutorial-path my-tutorials greeting` (without `--allow-shell`)
+  shows the standalone trust gate refusing untrusted hook code
 - `cat my-tutorials/greeting.md` lets you inspect the final shell, editor,
   hook, shell-check, and question metadata directly
 @


### PR DESCRIPTION
Make the built-in lessons describe list, run, review, and install by
verb so they read correctly for both the tutorial and pytorial console
scripts as well as embedded hosts. Relax the step validators to accept
either entrypoint while keeping the change scoped to tutorial sources.
